### PR TITLE
Fixed warning when translated value is an array

### DIFF
--- a/lib/actions/backend/shopBackendWelcome.action.php
+++ b/lib/actions/backend/shopBackendWelcome.action.php
@@ -109,7 +109,9 @@ class shopBackendWelcomeAction extends waViewAction
 
                                 if ($feature['id'] && !empty($feature['selectable']) && !empty($feature['values'])) {
                                     foreach ($feature['values'] as & $value) {
-                                        $value = ifempty($this->translate[$value], $value);
+                                        if (is_string($value)) {
+                                            $value = ifempty($this->translate[$value], $value);
+                                        }
                                     }
                                     unset($value);
                                     $feature_model->setValues($feature, $feature['values'], false, true);


### PR DESCRIPTION
Values of the dimension features are arrays with value and unit so they could not be used as array keys.
