### PR TITLE
Fix. Не работает Upselling по условию "Совпадает с базовым".

### DIFF
--- a/lib/classes/shopProductsCollection.class.php
+++ b/lib/classes/shopProductsCollection.class.php
@@ -471,6 +471,33 @@ class shopProductsCollection
                         $this->group_by = 'p.id';
                     }
                     break;
+                case 'same':
+                    if(!$product->features[$row['feature']]) {
+                        // Если нет фичи, не можем подобрать связанные продукты.
+                        $this->where[] = '0';
+                        break;
+                    }
+
+
+                    if ($model->fieldExists($row['feature'])) {
+                        $this->where[] = 'p.'.$row['feature']." = '".$model->escape($product->features[$row['feature']])."'";
+                    } else {
+
+                        $feature_join_index++;
+                        $this->joins[] = array(
+                            'table' => 'shop_product_features',
+                            'alias' => 'pf'.$feature_join_index
+                        );
+                        $this->joins[] = array(
+                            'table' => 'shop_feature_values_varchar',
+                            'alias' => 'fvv'.$feature_join_index,
+                            'on'    => 'pf'.$feature_join_index.'.feature_value_id = fvv'.$feature_join_index.'.id'
+                        );
+                        $this->where[] = 'fvv'.$feature_join_index.".value = '".$model->escape($product->features[$row['feature']])."'";
+                        $this->where[] = 'fvv'.$feature_join_index.".feature_id = ".(int) $row['feature_id'];
+                        $this->group_by = 'p.id';
+                    }
+                    break;
                 case 'any':
                 case 'all':
                     if ($model->fieldExists($row['feature'])) {


### PR DESCRIPTION
Если в админке по какой-то характеристике было выбрано "Совпадает с базовым", фильтр не учитывал эту характеристику вообще.

Предложенный вариант:
1. Работает только с типом varchar
2. Не работает с множественными полями
