### PR TITLE
Update shopPlugin.class.php

### DIFF
--- a/lib/classes/plugins/shopPlugin.class.php
+++ b/lib/classes/plugins/shopPlugin.class.php
@@ -38,7 +38,7 @@ abstract class shopPlugin extends waPlugin
             if ($settings_config = $this->getSettingsConfig()) {
                 foreach ($settings_config as $key => $row) {
                     if (!isset($this->settings[$key])) {
-                        $this->settings[$key] = isset($row['value']) ? $row['value'] : null;
+                        $this->settings[$key] = isset($row) ? $row : null;
                     }
                 }
             }


### PR DESCRIPTION
The settings in /config/settings.php are stored in the format key => value, not a 
array(key => array ("value" => "some_var"))
