### PR TITLE
Update shopWorkflowCreateAction.class.php

### DIFF
--- a/lib/workflow/shopWorkflowCreateAction.class.php
+++ b/lib/workflow/shopWorkflowCreateAction.class.php
@@ -171,6 +171,11 @@ class shopWorkflowCreateAction extends shopWorkflowAction
         $order_log_model = new shopOrderLogModel();
         $order_log_model->add($data);
 
+        /**
+         * @event order_action.create
+         */
+        wa('shop')->event('order_action.create', $data);
+
         $order_model = new shopOrderModel();
         $order = $order_model->getById($order_id);
         // send notifications
@@ -180,11 +185,6 @@ class shopWorkflowCreateAction extends shopWorkflowAction
             'status' => $this->getWorkflow()->getStateById($data['after_state_id'])->getName(),
             'action_data' => $data
         ));
-
-        /**
-         * @event order_action.create
-         */
-        wa('shop')->event('order_action.create', $data);
 
         // Update stock count, but take into account 'update_stock_count_on_create_order'-setting
         $app_settings_model = new waAppSettingsModel();


### PR DESCRIPTION
Хук order_action.create правильнее расположить перед отправкой уведомления, а не после него. Это, во-первых, позволяет плагинам так же вносить изменения в сформированный и сохраненный заказ. Во-вторых, при этом уведомление будет содержать заведомо адекватную информацию о заказе, так как после отправки уведомления программное изменение заказа станет невозможным.
