### PR TITLE
Mistype fix

### DIFF
--- a/lib/config/data/welcome/type_autoparts.php
+++ b/lib/config/data/welcome/type_autoparts.php
@@ -17,7 +17,7 @@ return array(
         'suitable_models' => array(
             'name' => 'Suitable automobile models',
             'type' => shopFeatureModel::TYPE_VARCHAR,
-            'selecable' => true,
+            'selectable' => true,
             'multiple' => true
         ),
         'weight' => array(


### PR DESCRIPTION
Опечатка в стандартных конфигуряциях. По крайней мере параметр `suitable models` из #50 становится чекбоксами, а не непонятным параметром
