### PR TITLE
Set a Cart ID not only from cookies. Resolves #61

### DIFF
--- a/lib/actions/frontend/shopFrontendCartAdd.controller.php
+++ b/lib/actions/frontend/shopFrontendCartAdd.controller.php
@@ -31,7 +31,7 @@ class shopFrontendCartAddController extends waJsonController
                 $service = $service_model->getById($data['service_id']);
                 $parent['service_variant_id'] = $service['variant_id'];
             }
-            $cart = new shopCart();
+            $cart = new shopCart($code);
             
             $id = $cart->addItem($parent);
             $total = $cart->total();
@@ -161,7 +161,7 @@ class shopFrontendCartAddController extends waJsonController
                 }
             }
             // update shop cart session data
-            $shop_cart = new shopCart();
+            $shop_cart = new shopCart($code);
             wa()->getStorage()->remove('shop/cart');
             $total = $shop_cart->total();
 

--- a/lib/classes/shopCart.class.php
+++ b/lib/classes/shopCart.class.php
@@ -9,9 +9,13 @@ class shopCart
      */
     protected $model;
 
-    public function __construct()
+    /**
+     * Constructor
+     * @param string $code Cart unique ID
+     */
+    public function __construct($code='')
     {
-        $this->code = waRequest::cookie(self::COOKIE_KEY, '');
+        $this->code = waRequest::cookie(self::COOKIE_KEY, $code);
         $this->model = new shopCartItemsModel();
     }
 


### PR DESCRIPTION
Из-за последних изменений во фреймворке номер корзины из cookie Не всегда доступен. Добавил возможность указать его напрямую при инициализации shopCart.
