### PR TITLE
Добавлен хук image_thumb

### DIFF
--- a/lib/config/data/thumb.php
+++ b/lib/config/data/thumb.php
@@ -63,7 +63,16 @@ if ($file && file_exists($original_path) && !file_exists($thumb_path)) {
         $max_size *= 2;
     }
     $image = shopImage::generateThumb($original_path, $size, $max_size);
+    
     if ($image) {
+        
+        /**
+         * Extend thumbs for product images
+         * Make extra workup
+         * @event image_thumb
+         */
+        wa()->event('image_thumb', $image);
+    
         $image->save($thumb_path, $app_config->getSaveQuality($enable_2x));
         clearstatcache();
     }


### PR DESCRIPTION
На основании его можно сделать (и будут сделаны :)) более гибкие вотермарки. Например:
1. При перегенерации превью, вотермарки переналожатся (если были изменены).
2. Можно избежать обрезки вотермарков при обрезке изображения без сохранения пропорций.
3. Можно не накладывать на совсем маленькие превьюшки.

Ну или сделать чёрно-белыми все превьюхи 48х48.
