### PR TITLE
Добавлен хук image_thumb

### DIFF
--- a/lib/classes/shopImage.class.php
+++ b/lib/classes/shopImage.class.php
@@ -170,6 +170,14 @@ class shopImage
                 throw new waException("Unknown type");
                 break;
         }
+
+        /**
+         * Extend thumbs for product images
+         * Make extra workup
+         * @event image_thumb
+         */
+        wa()->event('image_thumb', $image);
+        
         return $image;
     }
 


### PR DESCRIPTION
На основании его можно сделать (и будут сделаны :)) более гибкие вотермарки. Например:
1. При перегенерации превью, вотермарки переналожатся (если были изменены).
2. Можно избежать обрезки вотермарков при обрезке изображения без сохранения пропорций.
3. Можно не накладывать на совсем маленькие превьюшки.

Ну или сделать чёрно-белыми все превьюхи 48х48.
