### PR TITLE
Хук cart_add

### DIFF
--- a/lib/actions/frontend/shopFrontendCartAdd.controller.php
+++ b/lib/actions/frontend/shopFrontendCartAdd.controller.php
@@ -160,6 +160,13 @@ class shopFrontendCartAddController extends waJsonController
                     }
                 }
             }
+            
+            /**
+             * @event cart_add
+             * @param int $item_id
+             */
+            wa()->event('cart_add', $item_id);
+            
             // update shop cart session data
             $shop_cart = new shopCart($code);
             wa()->getStorage()->remove('shop/cart');


### PR DESCRIPTION
Обсуждали в #80.

Уже нужен в плагине "Брошенные корзины". Без него возникли проблемы у некоторых клиентов (один точно обратился). Т.к. текущее решение на основе хука frontend_head работает некорректно: в случае нескольких витрин на одном домене сохраняет ту, на которой пользователь был в последний раз, а не ту, на которой товар добавлен.

Могут быть также и другие применения: для товаров с дробным количеством или с ценой за погонный метр. Без него пришлось реализовывать свой /cart/add/ на сайте lafasada.ru.

Прошу не затягивать с решением: если такого хука не будет, нужно искать другое решение.
[Некоторые хуки](https://github.com/webasyst/webasyst-framework/pull/53) уже 2 обновления вручную переношу :)
