### PR TITLE
Proposed new event `customer_signup`

### DIFF
--- a/lib/actions/shopSignup.action.php
+++ b/lib/actions/shopSignup.action.php
@@ -34,5 +34,6 @@ class shopSignupAction extends waSignupAction
     public function afterSignup(waContact $contact)
     {
         $contact->addToCategory($this->getAppId());
+        wa()->event('customer_signup', $contact);
     }
 }


### PR DESCRIPTION
Новое событие/хук при создании учетной записи покупателя. К сожалению, во фреймворке (пока?) не предусмотрено общесистемных событий, поэтому хук будет вызываться только если в качестве приложения, ответственного за регистрацию и авторизацию, выбрано приложение "Магазин". :cry: 

Тем не менее хук может помочь расширению функционала — для различного рода партнерских программ, раздачи бонусов "за регистрацию" и т.п.
