### PR TITLE
Check for plugin image/icon

### DIFF
--- a/lib/actions/settings/affiliate/shopSettingsAffiliate.action.php
+++ b/lib/actions/settings/affiliate/shopSettingsAffiliate.action.php
@@ -54,7 +54,9 @@ class shopSettingsAffiliateAction extends waViewAction
             if (substr($k, -7) == '-plugin') {
                 $plugin_id = substr($k, 0, -7);
                 $plugin_info = $config->getPluginInfo($plugin_id);
-                $p['img'] = $plugin_info['img'];
+                if (isset($plugin_info['img'])) {
+                    $p['img'] = $plugin_info['img'];
+                }
             }
         }
         $this->view->assign('plugins', $plugins);


### PR DESCRIPTION
В шаблоне настроек обрабатывается ситуация, когда у плагина не указана иконка, а в экшене — нет.
