### PR TITLE
New event shop.contacts_delete. Retranslates the system event to shop plugins

### DIFF
--- a/lib/handlers/contacts.delete.handler.php
+++ b/lib/handlers/contacts.delete.handler.php
@@ -64,6 +64,13 @@ class shopContactsDeleteHandler extends waEventHandler
 
         // !!! TODO: take a look to other models related with contacts
 
+        /**
+         * @event contacts_delete
+         * @param array[] int $contact_ids array of contact's ID
+         * @return void
+         */
+        wa()->event(array('shop', 'contacts_delete'), $params);
+
     }
 
     public function extractContactInfo($contact)


### PR DESCRIPTION
Ретрансляция системного события при удалении контакта своим плагинам. Во всяком случае приложение blog так поступает, почему бы это не сделать в shop? Будет полезно, как минимум, для различных скидочных плагинов, генерирующих купоны или других, привязывающихся к покупателю.
