### PR TITLE
Исправление бага с csrf

### DIFF
--- a/templates/actions/product/Product.html
+++ b/templates/actions/product/Product.html
@@ -933,7 +933,7 @@
     $(function() {
     
         $('#s-product-description-content').data('uploadFields', {
-            '_csrf': "{waRequest::cookie('_csrf', '')}"
+            '_csrf': '{waRequest::cookie('_csrf', '')}'
         });
     
         $.product.setData('main','stocks',{$stocks|json_encode});


### PR DESCRIPTION
Поправил небольшой, но очень неприятный баг.
Иногда в csrf появляются двойные ковычки, что ломает javascript и не работает редактирование и добавление товаров в бэкенде.
