### PR TITLE
На обсуждение хук "orders_collection.filter"

### DIFF
--- a/lib/classes/shopOrdersCollection.class.php
+++ b/lib/classes/shopOrdersCollection.class.php
@@ -51,6 +51,13 @@ class shopOrdersCollection
             $this->options[$k] = $v;
         }
         $this->setHash($hash);
+        
+        /**
+         * @event orders_collection.filter
+         * @param shopOrdersCollection $this
+         * @return void
+         */
+        wa()->event('orders_collection.filter', $this);
     }
 
     public function setOptions($options)


### PR DESCRIPTION
Нужен для разграничения прав региональных менеджеров. [Вопрос](http://www.webasyst.ru/help/2105/prava-dostupa-menedzherov/) в Хабе + столкнулся с подобной задачей в конкретном проекте.

Также можно, например, реализовать фильтрацию заказов в Бекенде (статус "выполнен", витрина1, регион ...).
