### PR TITLE
Update product.cart.html

### DIFF
--- a/themes/ascetic/product.cart.html
+++ b/themes/ascetic/product.cart.html
@@ -1,4 +1,4 @@
-<form id="cart-form" method="post" action="{$wa->getUrl('/frontendCart/add')}">
+<form id="cart-form" method="post" action="{$wa->getUrl('/frontendCart/add')}" autocomplete="off">
 
     <!-- sku -->
     <h4>{sprintf('[`Buy %s`]',$product.name|escape)}</h4>


### PR DESCRIPTION
Отключение autocomplete формы для Firefox.
Попробуйте на товаре с Артикулами (через список и через характеристики) и/или услугами, выбрать артикул или услугу, а затем обновить страницу.
Все браузеры сбрасывают выбор, а Firefox помнит.
Это вызывает некоторые неудобства, особенно если артикул или услуга изменяет цену.
В крайнем случае можно отключить autocomplete не для всей формы, а только для `<select class="sku-feature">`, `<input name="sku_id" type="radio">`, `<select class="service-variants">`.
По остальным темам предлагаю также выполнить эти правки кода
