### PR TITLE
Merge contacts only when additional contacts aren't empty. Refs: webasyst/webasyst-framework@1472d40

### DIFF
--- a/lib/handlers/contacts.merge.handler.php
+++ b/lib/handlers/contacts.merge.handler.php
@@ -11,63 +11,65 @@ class shopContactsMergeHandler extends waEventHandler
         $merge_ids = $params['contacts'];
         $all_ids = array_merge($merge_ids, array($master_id));
 
-        $m = new waModel();
+        if($merge_ids) {
 
-        //
-        // All the simple cases: update contact_id in tables
-        //
-        foreach(array(
-            array('shop_cart_items', 'contact_id'),
-            array('shop_checkout_flow', 'contact_id'),
-            array('shop_order', 'contact_id'),
-            array('shop_order_log', 'contact_id'),
-            array('shop_product', 'contact_id'),
-            array('shop_product_reviews', 'contact_id'),
-            array('shop_affiliate_transaction', 'contact_id'), // also see below
+            $m = new waModel();
 
-            // No need to do this since users are never merged into other contacts
-            //array('shop_coupon', 'create_contact_id'),
-            //array('shop_page', 'create_contact_id'),
-            //array('shop_product_pages', 'create_contact_id'),
-        ) as $pair)
-        {
-            list($table, $field) = $pair;
-            $sql = "UPDATE $table SET $field = :master WHERE $field in (:ids)";
-            $m->exec($sql, array('master' => $master_id, 'ids' => $merge_ids));
-        }
+            //
+            // All the simple cases: update contact_id in tables
+            //
+            foreach (array(
+                         array('shop_cart_items', 'contact_id'),
+                         array('shop_checkout_flow', 'contact_id'),
+                         array('shop_order', 'contact_id'),
+                         array('shop_order_log', 'contact_id'),
+                         array('shop_product', 'contact_id'),
+                         array('shop_product_reviews', 'contact_id'),
+                         array('shop_affiliate_transaction', 'contact_id'), // also see below
 
-        //
-        // shop_affiliate_transaction
-        //
-        $balance = 0.0;
-        $sql = "SELECT * FROM shop_affiliate_transaction WHERE contact_id=? ORDER BY id";
-        foreach($m->query($sql, $master_id) as $row) {
-            $balance += $row['amount'];
-            if ($row['balance'] != $balance) {
-                $m->exec("UPDATE shop_affiliate_transaction SET balance=? WHERE id=?", $balance, $row['id']);
+                         // No need to do this since users are never merged into other contacts
+                         //array('shop_coupon', 'create_contact_id'),
+                         //array('shop_page', 'create_contact_id'),
+                         //array('shop_product_pages', 'create_contact_id'),
+                     ) as $pair) {
+                list($table, $field) = $pair;
+                $sql = "UPDATE $table SET $field = :master WHERE $field in (:ids)";
+                $m->exec($sql, array('master' => $master_id, 'ids' => $merge_ids));
             }
-        }
-        $affiliate_bonus = $balance;
 
-        //
-        // shop_customer
-        //
+            //
+            // shop_affiliate_transaction
+            //
+            $balance = 0.0;
+            $sql = "SELECT * FROM shop_affiliate_transaction WHERE contact_id=? ORDER BY id";
+            foreach ($m->query($sql, $master_id) as $row) {
+                $balance += $row['amount'];
+                if ($row['balance'] != $balance) {
+                    $m->exec("UPDATE shop_affiliate_transaction SET balance=? WHERE id=?", $balance, $row['id']);
+                }
+            }
+            $affiliate_bonus = $balance;
 
-        // Make sure it exists
-        $cm = new shopCustomerModel();
-        $cm->createFromContact($master_id);
+            //
+            // shop_customer
+            //
 
-        $sql = "SELECT SUM(number_of_orders) FROM shop_customer WHERE contact_id IN (:ids)";
-        $number_of_orders = $m->query($sql, array('ids' => $all_ids))->fetchField();
+            // Make sure it exists
+            $cm = new shopCustomerModel();
+            $cm->createFromContact($master_id);
 
-        $sql = "SELECT MAX(last_order_id) FROM shop_customer WHERE contact_id IN (:ids)";
-        $last_order_id = $m->query($sql, array('ids' => $all_ids))->fetchField();
+            $sql = "SELECT SUM(number_of_orders) FROM shop_customer WHERE contact_id IN (:ids)";
+            $number_of_orders = $m->query($sql, array('ids' => $all_ids))->fetchField();
 
-        $sql = "UPDATE shop_customer SET number_of_orders=?, last_order_id=?, affiliate_bonus=? WHERE contact_id=?";
-        $m->exec($sql, ifempty($number_of_orders, 0), ifempty($last_order_id, null), ifempty($affiliate_bonus, 0), $master_id);
+            $sql = "SELECT MAX(last_order_id) FROM shop_customer WHERE contact_id IN (:ids)";
+            $last_order_id = $m->query($sql, array('ids' => $all_ids))->fetchField();
 
-        if ($number_of_orders) {
-            shopCustomer::recalculateTotalSpent($master_id);
+            $sql = "UPDATE shop_customer SET number_of_orders=?, last_order_id=?, affiliate_bonus=? WHERE contact_id=?";
+            $m->exec($sql, ifempty($number_of_orders, 0), ifempty($last_order_id, null), ifempty($affiliate_bonus, 0), $master_id);
+
+            if ($number_of_orders) {
+                shopCustomer::recalculateTotalSpent($master_id);
+            }
         }
 
         wa('shop')->event('customers_merge', $params);


### PR DESCRIPTION
Та же проблема, что и webasyst/webasyst-framework@1472d4045fb63eb33328210e1363d8f6d45aa39b . При включенном подтверждении регистрации по email срабатывает этот handler, однако ему передается пустой массив контактов для слияния и при первом же обновлении первой таблицы mySQL выдает ошибку из-за пустого `IN()` в запросе
