### PR TITLE
Fix shipping variants update on address fields change

### DIFF
--- a/js/order/edit.js
+++ b/js/order/edit.js
@@ -293,7 +293,7 @@ $.order_edit = {
                     $.order_edit.updateTotal
         );
 
-        $(".s-order-customer-details").on('change', 'select', function () {
+        $(".s-order-customer-details").on('change', 'input[type=text],select', function () {
             if  ($(this).attr('name').indexOf('address')) {
                 $.order_edit.updateTotal();
             }


### PR DESCRIPTION
Некоторые плагины считают доставку не только исходя из страны и региона, которые можно выбрать из `<select>`, но и на основе названия города и/или почтового индекса. Однако обновление вариантов доставки сейчас происходит только при изменении `<select>`.

Добавил также обработку изменений `<input type="text">` в адресной форме
