### PR TITLE
Неопределённая переменная $cache в некоторых случаях

### DIFF
--- a/lib/model/shopCategory.model.php
+++ b/lib/model/shopCategory.model.php
@@ -103,7 +103,7 @@ class shopCategoryModel extends waNestedSetModel
             $sql .= " ORDER BY c.`{$this->left}`";
 
             $data = $this->query($sql, array('left' => $left, 'right' => $right, 'depth' => $depth))->fetchAll($this->id);
-            if (!$id && $depth == null && $route && $cache) {
+            if (!$id && $depth == null && $route && ifset($cache)) {
                 $cache->set($cache_key, $data, 3600, 'categories');
             }
         }


### PR DESCRIPTION
Например вызов в шаблоне с отрицательной глубиной {$categories = $wa->shop->categories(0, -1, false)}
В новом проекте встретилось. Notice глаз резанул, полез выяснять. Чтобы не перебирать все возможные варианты кривых условий в shopViewHelper->categoris() -  сделал ifset в модели.
