### PR TITLE
Convert el_selected to string

### DIFF
--- a/js/order/edit.js
+++ b/js/order/edit.js
@@ -570,6 +570,7 @@ $.order_edit = {
 
                     if (found) {
                         el.val(el_selected);
+                        el_selected += '';
                         if (!shipping_methods[el_selected].external || data['shipping_id'] == el_selected.split('.')[0]) {
                             el.trigger($.Event('change', {
                                 triggered_by_updateTotal: 1


### PR DESCRIPTION
Иногда в этом месте `el_selected` оказывается преобразованной в `number` и дальнейшие манипуляции со `.split()` вызывают `TypeError`.

Принудительно конвертируем `el_selected` в строку.
