### PR TITLE
Mistype in address change detection

### DIFF
--- a/lib/actions/order/shopOrderSave.controller.php
+++ b/lib/actions/order/shopOrderSave.controller.php
@@ -230,7 +230,7 @@ class shopOrderSaveController extends waJsonController
                     break;
                 }
             }
-            if ($flag) {
+            if (!$flag) {
                 $tmp = $contact['address.'.$ext];
                 $tmp[$i] = ($ext == 'shipping') ? $this->shipping_address : $this->billing_address;
                 $contact['address.'.$ext] = $tmp;


### PR DESCRIPTION
**Критично**
Из-за этой опечатки плагин доставки, вызываемый позже в этом же контроллере, получает старый адрес доставки. Если набор вариантов доставки зависит от изменившегося поля, то это становится проблемой.
Код в условии должен срабатывать при изменении адреса доставки, если я правильно все понял, а он наоборот срабатывает только если адрес не изменился.
