### PR TITLE
Switched private to protected access of extendItems in shopPrintformPlugin class

### DIFF
--- a/lib/classes/plugins/shopPrintformPlugin.class.php
+++ b/lib/classes/plugins/shopPrintformPlugin.class.php
@@ -154,7 +154,7 @@ abstract class shopPrintformPlugin extends shopPlugin
      * @param mixed[] $params
      * @return array
      */
-    private function extendItems(&$order, $params)
+    protected function extendItems(&$order, $params)
     {
         $items = $order->items;
         $product_model = new shopProductModel();


### PR DESCRIPTION
Не получается (естественно :grin: ) перегрузить этот метод. Вернее **только этот метод** :laughing:  Собрался сделать так, чтобы скидка не вычиталась из стоимости каждой позиции заказа, пришлось вместе с `extendItems()` также и `getOrder()` перегружать причем простым копированием.
