### PR TITLE
Allow to pass third parameter to the parent getProductValues

### DIFF
--- a/lib/model/shopFeatureValuesDimension.model.php
+++ b/lib/model/shopFeatureValuesDimension.model.php
@@ -8,9 +8,9 @@ class shopFeatureValuesDimensionModel extends shopFeatureValuesModel
         return new shopDimensionValue($row);
     }
 
-    public function getProductValues($product_id, $feature_id, $field = 'value')
+    public function getProductValues($product_id, $feature_id, $field = 'value_base_unit')
     {
-        return parent::getProductValues($product_id, $feature_id, 'value_base_unit');
+        return parent::getProductValues($product_id, $feature_id, $field);
     }
 
     protected function parseValue($value, $type)


### PR DESCRIPTION
Третий параметр у `shopFeatureValuesModel::()` может быть не только строкой, но и массивом. Однако `shopFeatureValuesDimensionModel` перегружает этот метод и не дает передать список нужных полей, позволяя получить лишь массив значений в базовой единице измерения. :unamused: 

Сделал возможность передать третий параметр в родительский метод, а нынешнее значение сделал значением по умолчанию.
