### PR TITLE
Update shopYandexmarketPluginRun.controller.php

### DIFF
--- a/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php
+++ b/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php
@@ -2147,7 +2147,11 @@ SQL;
             }
             $value = str_replace(',', '.', sprintf($format, (double)$value));
         } else {
-            $value = sprintf($format, $value);
+			if (is_array($value)) {
+				$value = vsprintf($format, $value);
+			} else {
+				$value = sprintf($format, $value);
+			}
         }
         return $value;
     }


### PR DESCRIPTION
Видимо в sprintf где-то передается массив вместо строки что вызывает PHP Notice:  Array to string conversion in /home/.../wa-apps/shop/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php on line 2151
Может добавить проверку $value на наличие массива и использовать vsprintf.
