### PR TITLE
Ability to pass parameters via waRequest::param()

### DIFF
--- a/lib/workflow/shopWorkflowShipAction.class.php
+++ b/lib/workflow/shopWorkflowShipAction.class.php
@@ -14,11 +14,11 @@ class shopWorkflowShipAction extends shopWorkflowAction
         $text = array();
         $params = array();
 
-        if ( ( $tracking = waRequest::post('tracking_number', '', 'string'))) {
+        if ( ( $tracking = waRequest::post('tracking_number', waRequest::param('tracking_number', '', waRequest::TYPE_STRING), 'string'))) {
             $text[] = _w('Tracking number').': '.htmlspecialchars($tracking);
             $params['tracking_number'] = $tracking;
         }
-        if ( ( $courier_id = waRequest::post('courier_id', null, 'int'))) {
+        if ( ( $courier_id = waRequest::post('courier_id', waRequest::param('courier_id', null, waRequest::TYPE_INT), 'int'))) {
             $courier_model = new shopApiCourierModel();
             $courier = $courier_model->getById($courier_id);
             if ($courier) {


### PR DESCRIPTION
Нынешняя реализация преполагает только ручную отправку каждого заказа (к тому же по-отдельности). Было бы уместна возможность передать номер трека (и других параметров) через `waRequest::param()` в случае автоматической обработки заказа.
