### PR TITLE
Use type_id field as value for typePrefix

### DIFF
--- a/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginBackendSetup.action.php
+++ b/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginBackendSetup.action.php
@@ -177,6 +177,7 @@ class shopYandexmarketPluginBackendSetupAction extends waViewAction
             'sku'         => _w('SKU code'),
             'file_name'   => _w('Attachment'),
             'count'       => _w('In stock'),
+            'type_id'     => _w('Product type'),
         );
 
         $stock_model = new shopStockModel();


### PR DESCRIPTION
Now we can fill typePrefix with type name by type_id as it was designed.
