### PR TITLE
'redirect' plugin: fix for InSales

### DIFF
--- a/plugins/redirect/lib/shopRedirect.plugin.php
+++ b/plugins/redirect/lib/shopRedirect.plugin.php
@@ -549,10 +549,7 @@ JS;
                 }
             }
         } elseif (preg_match('@^/?page/([^/]+(/[^/]+)*)/?$@', $url, $matches)) {
-            $page = $this->pageModel()->getByField('url', $matches[1]);
-            if (!$page) {
-                $page = $this->pageModel()->getByField('url', $matches[1].'/');
-            }
+            $page = $this->pageModel()->select('*')->where('url IN(s:urls)', array('urls' => array($matches[1], $matches[1].'/')))->fetch();
             if ($p = $demo ? array('url' => '%page_url%') : $page) {
                 $redirect = $this->getPageUrl($p, $demo);
             }


### PR DESCRIPTION
Fixed redirect for InSales URLs as shown in plugin settings:

/collection/%category_slug% → /category/%category/full/url%/
/collection/%category_slug%/product/%product_slug% → /%product_url%/
/page/%page_url% → /%page_url%

Trailing slash and its absense are taken into account.
