### PR TITLE
Исправлен бесконечный вызов shopProductsCollection::prepare() в кастомных коллекциях.

### DIFF
--- a/lib/classes/shopProductsCollection.class.php
+++ b/lib/classes/shopProductsCollection.class.php
@@ -133,6 +133,9 @@ class shopProductsCollection
                 if (method_exists($this, $method)) {
                     $this->$method(isset($this->hash[1]) ? $this->hash[1] : '', $auto_title);
                 } else {
+                    
+                    $this->prepared = true;
+                    
                     $params = array(
                         'collection' => $this,
                         'auto_title' => $auto_title,
@@ -157,9 +160,6 @@ class shopProductsCollection
                 }
             }
 
-            if ($this->prepared) {
-                return;
-            }
             $this->prepared = true;
         }
     }


### PR DESCRIPTION
Даже не знаю как правильно описать :)

Столкнулся с ошибкой.
Если плагин пытается добавить сортировку через публичный метод orderBy, возникает бесконечный рекурсивный вызов.

Происходит из-за того, что в orderBy вызывается getSQL
http://dl1.joxi.net/drive/2016/09/16/0009/0563/614963/63/2486b3137e.jpg
а getSQL вызывает prepare, который ещё не prepared.

Сакральный смысл вызова getSQL я не понял, поэтому решил не трогать, а объявил prepared=true до вызова плагинов. Если ни один плагин не сработает, всё-равно будет брошено исключение.

Ну и за компанию
if ($this->prepared) {
   return;
}
в том месте лишено всякого смысла.
