### PR TITLE
Правка локализации для уведомлений по Email и SMS

### DIFF
--- a/lib/actions/settings/notifications/shopSettingsNotificationsAdd.action.php
+++ b/lib/actions/settings/notifications/shopSettingsNotificationsAdd.action.php
@@ -13,98 +13,26 @@ class shopSettingsNotificationsAddAction extends shopSettingsNotificationsAction
 
     protected static function getOrderCreateTemplate() {
         $template = file_get_contents(wa('shop')->getAppPath('templates/mail/Order.create.html'));
-        $locales = array(
-            "%1%" => _w('Qty'),
-            "%2%" => _w('Total'),
-            "%3%" => _w('Download'),
-            "%4%" => _w('Subtotal'),
-            "%5%" => _w('Discount'),
-            "%6%" => _w('Shipping'),
-            "%7%" => _w('Tax'),
-            "%9%" => _w('Contact info'),
-            "%10%" => _w('Email'),
-            "%11%" => _w('Ship to'),
-            "%12%" => _w('Bill to'),
-            "%13%" => _w('Phone'),
-            "%14%" => _w('Comment to the order'),
-            "%15%" => _w('View and manage your order'),
-            "%16%" => _w('PIN'),
-            "%17%" => sprintf( _w('Thank you for shopping at %s!'), '{$wa->shop->settings("name")}')
-        );
-
-        foreach ($locales as $index => $locale) {
-            $template = str_replace($index, $locale, $template);
-        }
-
         return $template;
     }
 
     protected static function getOrderConfirmedTemplate() {
         $template = file_get_contents(wa('shop')->getAppPath('templates/mail/Order.confirmed.html'));
-        $locales = array(
-            "%1%" => sprintf( _w('Hi %s'), '{$customer->get("name", "html")}'),
-            "%2%" => sprintf( _w('Your order %s has been confirmed and accepted for processing.'), '{$order.id}'),
-            "%contact_info%" => _w('Contact info'),
-            "%16%" => _w('PIN'),
-            "%17%" => sprintf( _w('Thank you for shopping at %s!'), '{$wa->shop->settings("name")}')
-        );
-
-        foreach ($locales as $index => $locale) {
-            $template = str_replace($index, $locale, $template);
-        }
-
         return $template;
     }
 
     protected static function getOrderShipmentTemplate() {
         $template = file_get_contents(wa('shop')->getAppPath('templates/mail/Order.shipment.html'));
-        $locales = array(
-            "%1%" => sprintf( _w('Hi %s'), '{$customer->get("name", "html")}'),
-            "%2%" => sprintf( _w('Your order %s has been shipped!'), '{$order.id}'),
-            "%3%" => sprintf( _w('The shipment tracking number is <strong>%s</strong>'), '{$action_data.params.tracking_number|escape}'),
-            "%contact_info%" => _w('Contact info'),
-            "%16%" => _w('PIN'),
-            "%17%" => sprintf( _w('Thank you for shopping at %s!'), '{$wa->shop->settings("name")}')
-        );
-
-        foreach ($locales as $index => $locale) {
-            $template = str_replace($index, $locale, $template);
-        }
-
         return $template;
     }
 
     protected static function getOrderCancelTemplate() {
         $template = file_get_contents(wa('shop')->getAppPath('templates/mail/Order.cancel.html'));
-        $locales = array(
-            "%1%" => sprintf( _w('Hi %s'), '{$customer.name|escape}'),
-            "%2%" => sprintf( _w('Your order %s has been cancelled. If you want your order to be re-opened, please contact us.'), '{$order.id}'),
-            "%contact_info%" => _w('Contact info'),
-            "%16%" => _w('PIN'),
-            "%17%" => sprintf( _w('Thank you for shopping at %s!'), '{$wa->shop->settings("name")}')
-        );
-
-        foreach ($locales as $index => $locale) {
-            $template = str_replace($index, $locale, $template);
-        }
-
         return $template;
     }
 
     protected static function getOrderStatusChangeTemplate() {
         $template = file_get_contents(wa('shop')->getAppPath('templates/mail/Order.status_change.html'));
-        $locales = array(
-            "%1%" => sprintf( _w('Hi %s'), '{$customer.name|escape}'),
-            "%2%" => sprintf( _w('Your order %s status has been updated to <strong>%s</strong>'), '{$order.id}', '{$status}'),
-            "%contact_info%" => _w('Contact info'),
-            "%16%" => _w('PIN'),
-            "%17%" => sprintf( _w('Thank you for shopping at %s!'), '{$wa->shop->settings("name")}')
-        );
-
-        foreach ($locales as $index => $locale) {
-            $template = str_replace($index, $locale, $template);
-        }
-
         return $template;
     }
 
@@ -113,34 +41,30 @@ class shopSettingsNotificationsAddAction extends shopSettingsNotificationsAction
         $result = array();
 
         /* NEW ORDER email notification template */
-        $result['order.create']['subject'] = sprintf( _w('New order %s'), '{$order.id}');
+        $result['order.create']['subject'] = '{sprintf("[`New order %s`]", $order.id)}';
         $result['order.create']['body'] = self::getOrderCreateTemplate();
-        $result['order.create']['sms'] = _w('We successfully accepted your order, and will contact you asap.') . ' ' . sprintf( _w('Your order number is %s. Order total: %s'), '{$order.id}', '{wa_currency($order.total, $order.currency)}');
+        $result['order.create']['sms'] = '[`We successfully accepted your order, and will contact you asap.`]' . ' {sprintf("[`Your order number is %s. Order total: %s`]", $order.id, wa_currency($order.total, $order.currency))}';
 
         /* order was CONFIRMED (accepted for processing) */
-        $result['order.process']['subject'] = sprintf( _w('Order %s has been confirmed'), '{$order.id}');
+        $result['order.process']['subject'] = '{sprintf("[`Order %s has been confirmed`]", $order.id)}';
         $result['order.process']['body'] = self::getOrderConfirmedTemplate();
-        $result['order.process']['sms'] = sprintf( _w('Your order %s has been confirmed and accepted for processing.'), '{$order.id}');
-
+        $result['order.process']['sms'] = '{sprintf("[`Your order %s has been confirmed and accepted for processing.`]", $order.id)}';
 
         /* order SHIPMENT (sending out) email notification template */
-        $result['order.ship']['subject'] = sprintf( _w('Order %s has been sent out!'), '{$order.id}');
+        $result['order.ship']['subject'] = '{sprintf("[`Order %s has been sent out!`]", $order.id)}';
         $result['order.ship']['body'] = self::getOrderShipmentTemplate();
-        $result['order.ship']['sms'] = sprintf( _w('Your order %s has been sent out!'), '{$order.id}' ) . '{if !empty($action_data.params.tracking_number)} '. _w('Tracking number').': {$action_data.params.tracking_number}' . '{/if}';
-
+        $result['order.ship']['sms'] = '{sprintf("[`Your order %s has been sent out!`]", $order.id)}' . '{if !empty($action_data.params.tracking_number)} ' . '[`Tracking number`]: {$action_data.params.tracking_number}' . '{/if}';
 
         /* order CANCELLATION email notification template */
-        $result['order.delete']['subject'] = sprintf( _w('Order %s has been cancelled'), '{$order.id}');
+        $result['order.delete']['subject'] = '{sprintf("[`Order %s has been cancelled`]", $order.id)}';
         $result['order.delete']['body'] = self::getOrderCancelTemplate();
-        $result['order.delete']['sms'] = sprintf( _w('Your order %s has been cancelled'), '{$order.id}');
-
+        $result['order.delete']['sms'] = '{sprintf("[`Your order %s has been cancelled`]", $order.id)}';
 
         /* MISC order status change email notification template */
-        $result['order']['subject'] = sprintf( _w('Order %s has been updated'), '{$order.id}');
+        $result['order']['subject'] = '{sprintf("[`Order %s has been updated`]", $order.id)}';
         $result['order']['body'] = self::getOrderStatusChangeTemplate();
-        $result['order']['sms'] = sprintf( _w('Your order %s status has been updated to “%s”'), '{$order.id}', '{$status}');
+        $result['order']['sms'] = '{sprintf("[`Your order %s status has been updated to “%s”`]", $order.id, $status)}';
 
         return $result;
-
     }
 }

--- a/templates/mail/Order.cancel.html
+++ b/templates/mail/Order.cancel.html
@@ -34,7 +34,7 @@ border-collapse:collapse
                         <table width="500" border="0" align="center" cellpadding="0" cellspacing="0" style="width: 100% !important;">
                             <tr>
                                 <td>
-                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>{$order.id}</b></font>
+                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>[`Order`] {$order.id} </b></font>
                                     <font style="color: #888">{$order.create_datetime|wa_date:'humandate'}</font>
                                 </td>
                                 <td style="text-align: right;">
@@ -63,7 +63,7 @@ border-collapse:collapse
                             font-family:Helvetica,Arial,sans-serif;
                             margin: 20px 0 0;
                             text-align:center;
-                            ">%17%</p>
+                            ">{sprintf("[`Thank you for shopping at %s!`]", $wa->shop->settings("name"))}</p>
                                     <p align="center" style="margin: 20px 0;">
                                         <a href="{$order_url}" style="
                                             text-decoration:none;
@@ -88,7 +88,7 @@ border-collapse:collapse
                                 text-align:center;
                                 text-transform: uppercase;
                                 ">
-                                            %16%: <b>{$order.params.auth_pin}</b>
+                                            [`PIN`]: <b>{$order.params.auth_pin}</b>
                                         </p>
                                     {/if}
                                 </td>
@@ -102,8 +102,8 @@ border-collapse:collapse
                 <tr>
                     <td bgcolor="{$_bonus_background}"></td>
                     <td bgcolor="{$_bonus_background}" style="padding: 12px 0 12px 0;">
-                        <p>%1%</p>
-                        <p>%2%</p>
+                        <p>{sprintf("[`Hi %s`]", $customer.name|escape)}</p>
+                        <p>{sprintf("[`Your order %s has been cancelled. If you want your order to be re-opened, please contact us.`]", $order.id)}</p>
                     </td>
                     <td bgcolor="{$_bonus_background}"></td>
                 </tr>
@@ -112,7 +112,7 @@ border-collapse:collapse
                 <tr>
                     <td></td>
                     <td style="padding: 24px 0 36px 0;">
-                        <h3 style="margin: 0;">%contact_info%</h3>
+                        <h3 style="margin: 0;">[`Contact info`]</h3>
                         {if strlen($wa->shop->settings("email"))}
                             <p style="margin: 10px 0 0;">
                                 [`Email`]: <a href="mailto:{$wa->shop->settings("email")}">{$wa->shop->settings("email")}</a>

--- a/templates/mail/Order.confirmed.html
+++ b/templates/mail/Order.confirmed.html
@@ -34,7 +34,7 @@ border-collapse:collapse
                         <table width="500" border="0" align="center" cellpadding="0" cellspacing="0" style="width: 100% !important;">
                             <tr>
                                 <td>
-                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>{$order.id}</b></font>
+                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>[`Order`] {$order.id} </b></font>
                                     <font style="color: #888">{$order.create_datetime|wa_date:'humandate'}</font>
                                 </td>
                                 <td style="text-align: right;">
@@ -63,7 +63,7 @@ border-collapse:collapse
                             font-family:Helvetica,Arial,sans-serif;
                             margin: 20px 0 0;
                             text-align:center;
-                            ">%17%</p>
+                            ">{sprintf("[`Thank you for shopping at %s!`]", $wa->shop->settings("name"))}</p>
                                     <p align="center" style="margin: 20px 0;">
                                         <a href="{$order_url}" style="
                                             text-decoration:none;
@@ -88,7 +88,7 @@ border-collapse:collapse
                                 text-align:center;
                                 text-transform: uppercase;
                                 ">
-                                            %16%: <b>{$order.params.auth_pin}</b>
+                                            [`PIN`]: <b>{$order.params.auth_pin}</b>
                                         </p>
                                     {/if}
                                 </td>
@@ -102,8 +102,8 @@ border-collapse:collapse
                 <tr>
                     <td bgcolor="{$_bonus_background}"></td>
                     <td bgcolor="{$_bonus_background}" style="padding: 12px 0 12px 0;">
-                        <p>%1%</p>
-                        <p>%2%</p>
+                        <p>{sprintf("[`Hi %s`]", $customer.name|escape)}</p>
+                        <p>{sprintf("[`Your order %s has been confirmed and accepted for processing.`]", $order.id)}</p>
                     </td>
                     <td bgcolor="{$_bonus_background}"></td>
                 </tr>
@@ -112,7 +112,7 @@ border-collapse:collapse
                 <tr>
                     <td></td>
                     <td style="padding: 24px 0 36px 0;">
-                        <h3 style="margin: 0;">%contact_info%</h3>
+                        <h3 style="margin: 0;">[`Contact info`]</h3>
                         {if strlen($wa->shop->settings("email"))}
                             <p style="margin: 10px 0 0;">
                                 [`Email`]: <a href="mailto:{$wa->shop->settings("email")}">{$wa->shop->settings("email")}</a>

--- a/templates/mail/Order.create.html
+++ b/templates/mail/Order.create.html
@@ -34,7 +34,7 @@
                         <table width="500" border="0" align="center" cellpadding="0" cellspacing="0" style="width: 100% !important;">
                             <tr>
                                 <td>
-                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>{$order.id}</b></font>
+                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>[`Order`] {$order.id} </b></font>
                                     <font style="color: #888">{$order.create_datetime|wa_date:'humandate'}</font>
                                 </td>
                                 <td style="text-align: right;">
@@ -63,7 +63,7 @@
                                         font-family:Helvetica,Arial,sans-serif;
                                         margin: 20px 0 0;
                                         text-align:center;
-                                        ">%17%</p>
+                                        ">{sprintf("[`Thank you for shopping at %s!`]", $wa->shop->settings("name"))}</p>
                                     <p align="center" style="margin: 20px 0;">
                                         <a href="{$order_url}" style="
                                         text-decoration:none;
@@ -88,7 +88,7 @@
                                             text-align:center;
                                             text-transform: uppercase;
                                             ">
-                                            %16%: <b>{$order.params.auth_pin}</b>
+                                            [`PIN`]: <b>{$order.params.auth_pin}</b>
                                         </p>
                                     {/if}
                                 </td>
@@ -135,7 +135,7 @@
                                                 {if $_is_service}+&nbsp;{/if}{$item.name|escape}
                                                 {if !empty($item.sku_code)} <font style="color: #aaaaaa; font-size: 0.8em;">{$item.sku_code|escape}</font>{/if}
                                             {/if}
-                                            {if !empty($item.download_link)}<a href="{$item.download_link}"><strong>%3%</strong></a>{/if}
+                                            {if !empty($item.download_link)}<a href="{$item.download_link}"><strong>[`Download`]</strong></a>{/if}
                                         </p>
                                     </td>
                                     <td style="padding: 8px 4px 8px 4px; white-space: nowrap; text-align: right; {$_border_style}">
@@ -156,24 +156,24 @@
                     <td style="padding: 20px 0; border-bottom: 1px solid {$_border_color}">
                         <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse:collapse; text-align: right;">
                             <tr>
-                                <td style="padding: 8px 0;">%4%</td>
+                                <td style="padding: 8px 0;">[`Subtotal`]</td>
                                 <td style="white-space: nowrap; width: 20%; padding: 8px 0 8px 8px;">{wa_currency($subtotal, $order.currency)}</td>
                             </tr>
                             <tr>
-                                <td style="padding: 8px 0;">%5%</td>
+                                <td style="padding: 8px 0;">[`Discount`]</td>
                                 <td style="white-space: nowrap; padding: 8px 0 8px 8px;">{wa_currency($order.discount, $order.currency)}</td>
                             </tr>
                             <tr>
-                                <td style="padding: 8px 0;">%6%</td>
+                                <td style="padding: 8px 0;">[`Shipping`]</td>
                                 <td style="white-space: nowrap; padding: 8px 0 8px 8px;">{wa_currency($order.shipping, $order.currency)}</td>
                             </tr>
                             <tr>
-                                <td style="padding: 8px 0;">%7%</td>
+                                <td style="padding: 8px 0;">[`Tax`]</td>
                                 <td style="white-space: nowrap; padding: 8px 0 8px 8px;">{wa_currency($order.tax, $order.currency)}</td>
                             </tr>
                             <tr>
                                 <td style="padding: 8px 0;">
-                                    <h3 style="font-size:18px;margin:0;">%2%</h3>
+                                    <h3 style="font-size:18px;margin:0;">[`Total`]</h3>
                                 </td>
                                 <td style="white-space: nowrap; padding: 8px 0 8px 8px;">
                                     <h3 style="font-size:18px;margin:0;">{wa_currency($order.total, $order.currency)}</h3>
@@ -208,7 +208,7 @@
                         <td style="border: 0;">
                         </td>
                         <td style="border: 0; padding: 16px 0 0;">
-                            <h3>%14%</h3>
+                            <h3>[`Comment to the order`]</h3>
                             <p style="margin: 10px 0 0;">
                                 <pre>{$order.comment|escape}</pre>
                             </p>
@@ -223,9 +223,9 @@
                     <td style="border: 0; padding: 16px 0;">
                         <b>
                             {if !empty($order.params.shipping_name)}
-                                <font style="color: #aaa;">%11%&nbsp;—</font>&nbsp;{$order.params.shipping_name}
+                                <font style="color: #aaa;">[`Ship to`]&nbsp;—</font>&nbsp;{$order.params.shipping_name}
                             {else}
-                                <font style="color: #aaa;">%11%</font>
+                                <font style="color: #aaa;">[`Ship to`]</font>
                             {/if}
                         </b>
                         <p style="margin: 10px 0 0;">
@@ -241,9 +241,9 @@
                     <td style="border: 0; padding: 16px 0;">
                         <b>
                             {if !empty($order.params.payment_name)}
-                                <font style="color: #aaa;">%12%&nbsp;—</font>&nbsp;{$order.params.payment_name}
+                                <font style="color: #aaa;">[`Bill to`]&nbsp;—</font>&nbsp;{$order.params.payment_name}
                             {else}
-                                <font style="color: #aaa;">%12%</font>
+                                <font style="color: #aaa;">[`Bill to`]</font>
                             {/if}
                         </b>
                         <p style="margin: 10px 0 0;">{$customer.name|escape}<br>{$billing_address}</p>
@@ -274,7 +274,7 @@
                                     [`Registered customers apply for affiliate bonuses and discounts on future orders.`]
 &nbsp;<a href="{$signup_url}" target="_blank">[`Create permanent user account`]</a>
                                 {else}
-                                    {sprintf('[`When this order is paid, your affiliate bonus will be increased to %s.`]', round($customer.affiliate_bonus + $add_affiliate_bonus, 2))}
+                                    {sprintf("[`When this order is paid, your affiliate bonus will be increased to %s.`]", round($customer.affiliate_bonus + $add_affiliate_bonus, 2))}
                                 {/if}
                                 </p>
 

--- a/templates/mail/Order.shipment.html
+++ b/templates/mail/Order.shipment.html
@@ -34,7 +34,7 @@ border-collapse:collapse
                         <table width="500" border="0" align="center" cellpadding="0" cellspacing="0" style="width: 100% !important;">
                             <tr>
                                 <td>
-                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>{$order.id}</b></font>
+                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>[`Order`] {$order.id} </b></font>
                                     <font style="color: #888">{$order.create_datetime|wa_date:'humandate'}</font>
                                 </td>
                                 <td style="text-align: right;">
@@ -63,7 +63,7 @@ border-collapse:collapse
                                 font-family:Helvetica,Arial,sans-serif;
                                 margin: 20px 0 0;
                                 text-align:center;
-                                ">%17%</p>
+                                ">{sprintf("[`Thank you for shopping at %s!`]", $wa->shop->settings("name"))}</p>
                                     <p align="center" style="margin: 20px 0;">
                                         <a href="{$order_url}" style="
                                             text-decoration:none;
@@ -88,7 +88,7 @@ border-collapse:collapse
                                     text-align:center;
                                     text-transform: uppercase;
                                     ">
-                                            %16%: <b>{$order.params.auth_pin}</b>
+                                            [`PIN`]: <b>{$order.params.auth_pin}</b>
                                         </p>
                                     {/if}
                                 </td>
@@ -102,10 +102,10 @@ border-collapse:collapse
                 <tr>
                     <td bgcolor="{$_bonus_background}"></td>
                     <td bgcolor="{$_bonus_background}" style="padding: 12px 0 12px 0;">
-                        <p>%1%</p>
-                        <p>%2%</p>
+                        <p>{sprintf("[`Hi %s`]", $customer.name|escape)}</p>
+                        <p>{sprintf("[`Your order %s has been shipped!`]", $order.id)}</p>
                         {if !empty($action_data.params.tracking_number)}
-                            <p>%3%</p>
+                            <p>{sprintf("[`The shipment tracking number is <strong>%s</strong>`]", $action_data.params.tracking_number|escape)}</p>
                         {/if}
                         {if !empty($action_data.params.tracking_number) && !empty($shipping_plugin)}
                             {$tracking = $shipping_plugin->tracking($action_data.params.tracking_number)}
@@ -121,7 +121,7 @@ border-collapse:collapse
                 <tr>
                     <td></td>
                     <td style="padding: 24px 0 36px 0;">
-                        <h3 style="margin: 0;">%contact_info%</h3>
+                        <h3 style="margin: 0;">[`Contact info`]</h3>
                         {if strlen($wa->shop->settings("email"))}
                             <p style="margin: 10px 0 0;">
                                 [`Email`]: <a href="mailto:{$wa->shop->settings("email")}">{$wa->shop->settings("email")}</a>

--- a/templates/mail/Order.status_change.html
+++ b/templates/mail/Order.status_change.html
@@ -34,7 +34,7 @@
                         <table width="500" border="0" align="center" cellpadding="0" cellspacing="0" style="width: 100% !important;">
                             <tr>
                                 <td>
-                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>{$order.id}</b></font>
+                                    <font style="font-weight: bold; font-size: 20px; margin: 0 12px 0 0;"><b>[`Order`] {$order.id} </b></font>
                                     <font style="color: #888">{$order.create_datetime|wa_date:'humandate'}</font>
                                 </td>
                                 <td style="text-align: right;">
@@ -63,7 +63,7 @@
                                     font-family:Helvetica,Arial,sans-serif;
                                     margin: 20px 0 0;
                                     text-align:center;
-                                    ">%17%</p>
+                                    ">{sprintf("[`Thank you for shopping at %s!`]", $wa->shop->settings("name"))}</p>
                                     <p align="center" style="margin: 20px 0;">
                                         <a href="{$order_url}" style="
                                             text-decoration:none;
@@ -88,7 +88,7 @@
                                         text-align:center;
                                         text-transform: uppercase;
                                         ">
-                                            %16%: <b>{$order.params.auth_pin}</b>
+                                            [`PIN`]: <b>{$order.params.auth_pin}</b>
                                         </p>
                                     {/if}
                                 </td>
@@ -102,8 +102,8 @@
                 <tr>
                     <td bgcolor="{$_bonus_background}"></td>
                     <td bgcolor="{$_bonus_background}" style="padding: 12px 0 12px 0;">
-                        <p>%1%</p>
-                        <p>%2%</p>
+                        <p>{sprintf("[`Hi %s`]", $customer.name|escape)}</p>
+                        <p>{sprintf("[`Your order %s status has been updated to <strong>%s</strong>`]", $order.id, $status)}</p>
                     </td>
                     <td bgcolor="{$_bonus_background}"></td>
                 </tr>
@@ -112,7 +112,7 @@
                 <tr>
                     <td></td>
                     <td style="padding: 24px 0 36px 0;">
-                        <h3 style="margin: 0;">%contact_info%</h3>
+                        <h3 style="margin: 0;">[`Contact info`]</h3>
                         {if strlen($wa->shop->settings("email"))}
                             <p style="margin: 10px 0 0;">
                                 [`Email`]: <a href="mailto:{$wa->shop->settings("email")}">{$wa->shop->settings("email")}</a>


### PR DESCRIPTION
_Описание исправленной ошибки:_ после чистой установки WA SS7 в песочнице, уведомления
по email приходили с текстом большей частью на английском языке. При
всех ли установках это случается или нет, не знаю.

Протестировал сделанные правки на изменённом дистрибутиве, скачанном с
http://www.shop-script.ru/platform/. Теперь после установки WA, в базе
данных текст в не переведённом виде с конструкциями вида [`...`] и
{sprintf("[`...`]", ...)}. Письма-уведомления теперь приходят полностью
на русском.

PS: одинарные косые кавычки здесь в тексте почему-то не отображаются... :-(
