### PR TITLE
Allow plugins to pass custom structured data to the frontend

### DIFF
--- a/lib/classes/checkout/shopCheckoutShipping.class.php
+++ b/lib/classes/checkout/shopCheckoutShipping.class.php
@@ -140,6 +140,9 @@ class shopCheckoutShipping extends shopCheckout
                         if (!empty($rate['comment'])) {
                             $m['comment'] = $rate['comment'];
                         }
+                        if (isset($rate['custom_data'])) {
+                            $m['custom_data'] = $rate['custom_data'];
+                        }
                     } else {
                         $m['rates'] = array();
                         $m['rate'] = null;


### PR DESCRIPTION
Используя дополнительный элемент массива плагины могут отправлять дополнительные данные для использования в шаблоне фронтенда.

Если расчет запрашивается callback-функцией фронтенда, то в callback уже сейчас можно вернуть любую структуру, главное чтобы в ней были обязательные поля. Однако при вызове расчета из экшена в шаблон передаются только ограниченное число полей.

Возможность расширять набор передаваемых данных может повысить функциональность магазина — тут могут быть гео-координаты, дополнительные описания, расписание работы и т.д.
