### PR TITLE
shopProductsCollection: WHERE trimming

### DIFF
--- a/lib/classes/shopProductsCollection.class.php
+++ b/lib/classes/shopProductsCollection.class.php
@@ -1151,7 +1151,7 @@ class shopProductsCollection
             }
         }
 
-        $where = $this->where;
+        $where = array_filter(array_map('trim', $this->where), 'strlen');
 
         if ($where) {
             $sql .= " WHERE ".implode(" AND ", $where);
@@ -1865,7 +1865,10 @@ class shopProductsCollection
      */
     public function addWhere($condition)
     {
-        $this->where[] = $condition;
+        $condition = trim($condition);
+        if (strlen($condition)) {
+            $this->where[] = $condition;
+        }
         return $this;
     }
 


### PR DESCRIPTION
If a plugin is not accurate enough to trim dynamically generated WHERE clause consisting of whitespaces, including newline characters, check whether its trimmed version is not empty to avoid a fatal error because of an incorrect SQL query with "WHERE" keyword followed by no condition.