### PR TITLE
Use the currency from the result of the plugin

### DIFF
--- a/lib/classes/checkout/shopCheckoutShipping.class.php
+++ b/lib/classes/checkout/shopCheckoutShipping.class.php
@@ -119,9 +119,11 @@ class shopCheckoutShipping extends shopCheckout
                             $r['rate'] = max($r['rate']);
                         }
 
+                        $r['currency'] = ifset($r['currency'], $m['currency']);
+
                         // Apply rounding. This converts all rates to current frontend currency.
-                        if ($r['rate'] && wa()->getSetting('round_shipping')) {
-                            $r['rate'] = shopRounding::roundCurrency(shop_currency($r['rate'], $m['currency'], $current_currency, false), $current_currency);
+                        if ($r['rate'] && (wa()->getSetting('round_shipping') || ($r['currency'] !== $current_currency))) {
+                            $r['rate'] = shopRounding::roundCurrency(shop_currency($r['rate'], $r['currency'], $current_currency, false), $current_currency);
                             $r['currency'] = $current_currency;
                         }
                     }
@@ -433,8 +435,8 @@ class shopCheckoutShipping extends shopCheckout
             if (is_array($result['rate'])) {
                 $result['rate'] = max($result['rate']);
             }
-            if ($currency != $current_currency) {
-                $result['rate'] = shop_currency($result['rate'], $currency, $current_currency, false);
+            if ($result['currency'] != $current_currency) {
+                $result['rate'] = shop_currency($result['rate'], $result['currency'], $current_currency, false);
             }
             // rounding
             if ($result['rate'] && wa()->getSetting('round_shipping')) {


### PR DESCRIPTION
В соответствии с [документацией](https://developers.webasyst.ru/cookbook/plugins/shipping-plugins/) плагин доставки возвращает результат расчета с указанием валюты, в которой указана стоимость доставки. И при этом нет никаких ограничений на то, что эта валюта должна совпадать с валютой, возвращаемой методом `allowedCurrency()`. Однако сейчас Shop-Script не обращает внимания на валюту, указанную в массиве с результатами расчета, полагаясь исключительно на `allowedCurrency()`

Решение неполное. Было бы неплохо, до кучи, еще проверять есть-ли в настройках валюта с указанным кодом **у каждого варианта** результата