### PR TITLE
Every workflowAction can have an attribute prohibiting the showing in the list for mass action

### DIFF
--- a/lib/actions/orders/shopOrders.action.php
+++ b/lib/actions/orders/shopOrders.action.php
@@ -16,7 +16,7 @@ class shopOrdersAction extends shopOrderListAction
         $workflow = new shopWorkflow();
         $actions = array();
         foreach ($workflow->getAvailableActions() as $action_id => $action) {
-            if (!isset($forbidden[$action_id]) && empty($action['internal'])) {
+            if (!isset($forbidden[$action_id]) && empty($action['internal']) && ifset($action['bulk'], true)) {
                 $actions[$action_id] = array(
                     'name' => ifset($action['name'], ''),
                     'style' => ifset($action['options']['style'])


### PR DESCRIPTION
Жестко заданный список действий, которые не отображаются в списке для массового выполнения — не очень хорошее решение. Предлагаю проверять конфиг дейсвтия в workflow на наличие какого-нибудь определенного атрибута, например `bulk` и, если он `false`, не показывать это действие в выпадающем списке