### PR TITLE
Редактирование заказа, скрываем значок скидки

### DIFF
--- a/js/order/edit.js
+++ b/js/order/edit.js
@@ -418,6 +418,7 @@ $.order_edit = {
         // When we get recalculated discount, update the fields accordingly
         $('#order-edit-form').on('order_total_updated', function(e, data) {
             if (!data.discount) {
+                $update_discount_button.hide();
                 return;
             }
 


### PR DESCRIPTION
Если у нас в наборе необходимое кол-во товаров для получения скидки, то мы видим голубую иконку.
Удаляем товары до тех пор, чтобы скидка не начислялась. Голубая иконка никуда не исчезнет. Это вводит граждан в заблуждение. Предлагаю скрывать голубую иконку, если нет скидок.