### PR TITLE
Вырезает <br/> в HTML-описании.

### DIFF
--- a/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php
+++ b/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php
@@ -1949,7 +1949,7 @@ SQL;
                 $html = !empty($info['options']['html']);
                 $value = preg_replace('@(<br\s*/?>)+@', $html ? '<br/>' : "\n", $value);
                 $value = preg_replace("@[\r\n]+@", "\n", $value);
-                $value = strip_tags($value, $html ? '<h3><p><ul><li><br/>' : null);
+                $value = strip_tags($value, $html ? '<h3><p><ul><li><br><br/>' : null);
 
                 $value = trim($value);
                 if (mb_strlen($value) > 3000) {


### PR DESCRIPTION
Как я понял, проблема в PHP 5.3.3
5.3.4	strip_tags() ignores self-closing XHTML tags in allowable_tags.