### PR TITLE
Исправлена ошибка: пустые страницы пагинации ?page=10000 отдавали код 200

### DIFF
--- a/lib/actions/frontend/shopFrontend.action.php
+++ b/lib/actions/frontend/shopFrontend.action.php
@@ -56,7 +56,7 @@ class shopFrontendAction extends waViewAction
         $offset = ($page - 1) * $limit;
         $count = $collection->count();
 
-        if($count <= $offset) {
+        if(($page > 1) && ($count <= $offset)) {
             throw new waException('Page not found', 404);
         }
 


### PR DESCRIPTION
По мотивам этого поста
https://support.webasyst.ru/20578/pustye-stranitsy-paginatsii/

Как вариант, можно вместо 404-го кода отправлять 302-м редиректом на первую страницу.
Не уверен, что будет правильнее для поисковиков, но для посетителей второй вариант, имхо, удобнее.

Комментарии, пожелания? :)