### PR TITLE
Исправление: вырезается начальный нуль

### DIFF
--- a/lib/classes/shopHelper.class.php
+++ b/lib/classes/shopHelper.class.php
@@ -458,7 +458,7 @@ class shopHelper
 
         $customer_delivery_time = null;
         if (!empty($order_params['shipping_params_desired_delivery.interval'])) {
-            if (preg_match('~^\d\d:\d\d-\d\d:\d\d$~', $order_params['shipping_params_desired_delivery.interval'])) {
+            if (preg_match('~^\d{1,2}:\d\d-\d{1,2}:\d\d$~', $order_params['shipping_params_desired_delivery.interval'])) {
                 list($from_hours, $from_minutes, $to_hours, $to_minutes) = preg_split('~:|-~', $order_params['shipping_params_desired_delivery.interval']);
                 $customer_delivery_time = compact('from_hours', 'from_minutes', 'to_hours', 'to_minutes');
             }


### PR DESCRIPTION
Исправление касаемо начального нуля, если интервал доставки курьером, например 09:00 - 12:00, то при вставке в INPUT [from] и [to] обрезается начальный нуль, в скрипте /wa-system/shipping/waShipping.class.php
Подумал и решил, что лучше тогда в классе хелпере откорректировать regex проверку.