### PR TITLE
Исправлена ошибка вызова хука products_collection в других приложениях

### DIFF
--- a/lib/classes/shopProductsCollection.class.php
+++ b/lib/classes/shopProductsCollection.class.php
@@ -146,7 +146,7 @@ class shopProductsCollection
                      * @param array [string]boolean $params['add']
                      * @return bool null if ignored, true when something changed in the collection
                      */
-                    $processed = wa()->event('products_collection', $params);
+                    $processed = wa('shop')->event('products_collection', $params);
                     if (!$processed) {
                         throw new waException('Unknown collection hash type: '.htmlspecialchars($type));
                     }


### PR DESCRIPTION
Без этого вызов хука относится к активному приложению.
Например, обработчик shop.products_collection.handler.php работает в магазине, но не в самом приложении.