### PR TITLE
Fix: при расчёте доставки во фронтенде $this->getItems() не возвращает product_id.

### DIFF
--- a/lib/classes/checkout/shopCheckoutShipping.class.php
+++ b/lib/classes/checkout/shopCheckoutShipping.class.php
@@ -389,13 +389,9 @@ class shopCheckoutShipping extends shopCheckout
             if ($m !== null) {
                 $w = $w / $m;
             }
-            $items[] = array(
-                'name' => $item['name'],
-                'price' => $item['price'],
-                'currency' => $item['currency'],
-                'quantity' => $item['quantity'],
-                'weight' => $w,
-            );
+            
+            $item['weight'] = $w;
+            $items[] = $item;
         }
         return $items;
     }


### PR DESCRIPTION
Метод getItems не возвращает product_id, sku_code и много другого, что дальше по коду используется в shopHelper::workupOrderItems.

Также нормализация items тоже происходит не всегда. Например, тут же в shopCheckoutShipping при расчёте для одного плагина через метод getRate. Но это тема для отдельного PR. Если будет какой-то ответ по этому, могу смотреть дальше.