### PR TITLE
Добавлен хук backend_products.toolbar_badge_li

### DIFF
--- a/templates/actions/products/Products.html
+++ b/templates/actions/products/Products.html
@@ -52,6 +52,11 @@
     <div class="block">
         <h6 class="heading">[`Badge`]</h6>
         <ul class="menu-v with-icons">
+            
+            <!-- plugin hook: 'backend_products.toolbar_badge_li' -->
+            {* @event backend_products.%plugin_id%.toolbar_badge_li *}
+            {if !empty($backend_products)}{foreach $backend_products as $_}{ifset($_.toolbar_badge_li)}{/foreach}{/if}
+            
             {$badges = shopProductModel::badges()}
             {foreach $badges as $bid => $b}
                 <li data-action='set-badge' data-type="{$bid}">


### PR DESCRIPTION
Не совсем понял логику установки badges в магазине.
При редактировании товара выводятся по-одному, а в списке товаров через цикл нерасширяемого метода shopProductModel::badges().
В карточке товаров хук есть, а в списке товаров - нет.
По сути добавлен ещё один ключ массива backend_products.
Сделал по аналогии с соседними хуками.