### PR TITLE
Drop check for event type

### DIFF
--- a/js/order/edit.js
+++ b/js/order/edit.js
@@ -372,7 +372,7 @@ $.order_edit = {
              * handle only related changes
              */
             $.shop.trace('#shipping-custom change', [e, this]);
-            if (e.originalEvent && $(this).data('affects-rate')) {
+            if ($(this).data('affects-rate')) {
                 $.order_edit.updateTotal();
             }
         });


### PR DESCRIPTION
There is no reason to restrict updateTotal call only on native HTML DOM events