### PR TITLE
Для дальнейшего развития класса фикс!

### DIFF
--- a/lib/classes/shopOrder.class.php
+++ b/lib/classes/shopOrder.class.php
@@ -667,7 +667,7 @@ class shopOrder implements ArrayAccess
                 }
             } else {
                 $i['price'] = $this->formatValue($i['price'], 'float');
-                $i['quantity'] = $this->formatValue($i['price'], 'int');
+                $i['quantity'] = $this->formatValue($i['quantity'], 'int');
             }
             $subtotal += $i['price']*$i['quantity'];
         }


### PR DESCRIPTION
Правильная кастомизация данных, согласно типам в свойстве класса, во избежании ошибок с подсчетом в следующих версиях! 
При наследовании класса и изменении типа подсчета quantity на float для item[type]=product не правильно считался подитог!