### PR TITLE
shopProductsCollection::categoryPrepare() - 20x times faster

### DIFF
--- a/lib/classes/shopProductsCollection.class.php
+++ b/lib/classes/shopProductsCollection.class.php
@@ -2372,9 +2372,12 @@ SQL;
 
 
     /**
-     * @param waModel $table model of table to join
-     * @param string $subquery query builder to join
-     * @param string|null
+     * @param waModel $table waModel instance that will return table name
+     * @param string $subquery Builded subquery
+     * @param string $on ON statement used to join two tables, where :table will be replaced with alias
+     * @param bool $distinct If subquery has DISTINCT statement, we will not use DISTINCT in main query.
+     *                      It is important to set this param accordingly to gain performance.
+     * @param $type string JOIN type, e.g. INNER, LEFT, RIGHT, CROSS.
      * @return self
      */
     public function addJoinSubquery(waModel $model, $subquery, $on, $distinct = false, $type = null)
@@ -2392,9 +2395,7 @@ SQL;
         $alias .= $this->join_index[$alias];
 
         $join = array(
-            // If join subquery has DISTINCT, but join type is LEFT/RIGHT JOIN
-            // we still need to do distinct in the main query
-            'distinct' => $distinct && $type === null || $type === "INNER",
+            'distinct' => $distinct,
             'alias' => $alias,
             'type' => $type,
             'on' => str_replace(':table', $alias, $on),


### PR DESCRIPTION
Немного изменил логику построения SQL запросов на выборку товаров для статических категорий.

Что изменилось и зачем это нужно:

- теперь не используется `JOIN` + `DISTINCT` на огромной результирущей таблице, теперь мы сперва делаем выборку всех товаров в нужных нам категориях, затем делаем DISTINCT, после чего выбираем по ID этих товаров из таблицы `shop_product`
    - запрос выполняется **в 20 раз быстрее**, если раньше на 80к товаров это было 1.84 сек., сейчас - 0.09 сек. (Delta -95.10%)
    - вместе с этим, теперь быстрее выполняется запрос на подсчет количества товаров: раньше - 0.27 сек., сейчас - 0.13 сек. (Delta -51.85%)
    - теперь не используется `using temporary, using_filesort`, в результате чего снижается дисковое I/O
- мелкий рефакторинг, код для генерации алиаса вынесет в отдельный метод `generateAliasForTable`

Количество данных:
`shop_product`: 82066
`shop_category_products`: 165121


**ВАЖНО**: т.к. код не покрыт тестами, быстро проверить работоспособность невозможно. Немного потыкал, посравнивал результаты запросов - визуально все ок, нужно смотреть детальней
**ВАЖНО**: этот PR зависит от [этого](https://github.com/webasyst/webasyst-framework/pull/276), т.к. используется метод `waDbQuery::getSQL()`, который должен быть публичным.
**ВАЖНО**: производительность на маленьких таблицах не мерил, там, где JOIN + DISTINCT может влезть в буфер, запрос теоретически может работать быстрее, но не на столько, на сколько выигрывает в скорости на больших данных запрос из этого PR. 

Есть небольшие косяки в PHPDoc, чуть позже поправлю. 

@Leonix, @SergeR, @ZloyTip, @WinterSilence 

По мотивам этой темы: https://support.webasyst.ru/27218/medlennaya-skorost-raboty-s-bolshim-kolichestvo-tovarov-pravit-dvizhok-/
