### PR TITLE
В старом чекауте у items передавать type и product_id

### DIFF
--- a/lib/classes/checkout/shopCheckoutShipping.class.php
+++ b/lib/classes/checkout/shopCheckoutShipping.class.php
@@ -439,14 +439,16 @@ class shopCheckoutShipping extends shopCheckout
 
             foreach ($cart_items as $item) {
                 $this->items[] = array(
-                    'name'     => $item['name'],
-                    'price'    => $item['price'],
-                    'currency' => $item['currency'],
-                    'quantity' => $item['quantity'],
-                    'weight'   => ifset($item['weight']),
-                    'height'   => ifset($item['height']),
-                    'width'    => ifset($item['width']),
-                    'length'   => ifset($item['length']),
+                    'name'       => $item['name'],
+                    'price'      => $item['price'],
+                    'currency'   => $item['currency'],
+                    'quantity'   => $item['quantity'],
+                    'type'       => $item['type'],
+                    'product_id' => ifset($item['product_id']),
+                    'weight'     => ifset($item['weight']),
+                    'height'     => ifset($item['height']),
+                    'width'      => ifset($item['width']),
+                    'length'     => ifset($item['length']),
                 );
             }
         }


### PR DESCRIPTION
Проблема заключается в том, что при подписывании на хук shipping_package при разных формах чекаута приходит разный формат данных.

В новом чекауте - прекрасные данные, можно определить, что из этого товары, получить не только product_id, но и в целом product, идеально.

В старом же чекауте сейчас даже невозможно определить является ли item товаром.

Новый хук предназначен для того, чтоб плагин возвращал общие размеры отправления, исходя из товаров в корзине, но так получается, что я могу единственное что сделать с этими товарами при старом чекауте - это сложить их размеры. Какой от этого толк? Нужна хотя бы какая-то информация еще, тем более, что в новом чекауте она имеется.