### PR TITLE
Исправлена ошибка в плагине Яндекс.Маркет

### DIFF
--- a/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php
+++ b/plugins/yandexmarket/lib/actions/backend/shopYandexmarketPluginRun.controller.php
@@ -2088,7 +2088,7 @@ SQL;
                         $features_model = new shopProductFeaturesModel();
                     }
 
-                    $product['features'] = $features_model->getValues($product['id'], ifset($sku['id']));
+                    $product['features'] = $features_model->getValues($product['id'], ifset($sku['id']), null, ifempty($product['sku_type']));
                 }
                 if (strpos($param, ':')) {
                     $unit = null;


### PR DESCRIPTION
Дано:
1. Прайс сгруппирован по товарам.
2. Товары с несколькими артикулами в режиме "Выбор параметров". Например, несколько размеров.
3. Ошибка: При генерации прайса, если выбрать в <param/> характеристику "Размер", плагин её не увидит.