### PR TITLE
Передача по ссылке параметров уведомлений

### DIFF
--- a/lib/classes/shopNotifications.class.php
+++ b/lib/classes/shopNotifications.class.php
@@ -36,7 +36,7 @@ class shopNotifications
          */
         $event_params = [
             'event' => $event,
-            'notifications' => $notifications,
+            'notifications' => &$notifications,
             'data'  => &$data,
         ];
         wa('shop')->event('notifications_send.before', $event_params);
@@ -135,9 +135,9 @@ class shopNotifications
          */
         $event_params = [
             'id' => $id,
-            'notifications' => $n,
+            'notifications' => &$n,
             'data'  => &$data,
-            'to' => $to,
+            'to' => &$to,
         ];
         wa('shop')->event('notifications_send_one.before', $event_params);
 


### PR DESCRIPTION
Жалко что ли? :)

В `notifications_send_push`, например, текст передаётся по ссылке, а вот в остальных случаях его отредактировать нельзя.

Кроме того, возникла ситуация, когда получатель (менеджер) меняется динамически. Идеально подходит `notifications_send_one.before`, но переменная $to тоже не по ссылке была.