### PR TITLE
Объединение параметров поля в методе getShippingFields

### DIFF
--- a/lib/workflow/shopWorkflowAction.class.php
+++ b/lib/workflow/shopWorkflowAction.class.php
@@ -554,8 +554,7 @@ HTML;
                     if (!empty($order['params']['shipping_data_'.$name])) {
                         $control['value'] = $order['params']['shipping_data_'.$name];
                     }
-                    $control = array_merge($control, $params);
-                    $controls[$name] = waHtmlControl::getControl($control['control_type'], $name, $control);
+                    $controls[$name] = waHtmlControl::getControl($control['control_type'], $name, $control + $params);
                 }
             }
         }


### PR DESCRIPTION
При добавлении своих полей в веб-формы, которые должен заполнить пользователь при переводе отправления в указанный статус нет возможности переопределить параметры элемента. Мне нужно добавить свою "обертку" (control_wrapper)
```
public function getStateFields($state, waOrder $order = null, $params = array())
    {
        $fields = parent::getStateFields($state, $order, $params);
        switch ($state) {
            case self::STATE_READY:
                $fields['myplugin_field'] = array(
                    'control_wrapper' => '%s %s',
                    'control_type' => waHtmlControl::CUSTOM . ' ' . 'mypluginShipping::customField',
                );
                break;
        }
        return $fields;
    }
```
если метод mypluginShipping::customField добавляет скрытый html то начинает ехать верстка
![image](https://user-images.githubusercontent.com/5906352/69862886-47be6380-12bd-11ea-9890-715bcd13839b.png)
