### PR TITLE
Частичное подтверждение заказа: передача параметра order_data в capture.

### DIFF
--- a/lib/workflow/shopWorkflowCaptureAction.class.php
+++ b/lib/workflow/shopWorkflowCaptureAction.class.php
@@ -50,6 +50,8 @@ class shopWorkflowCaptureAction extends shopWorkflowPayAction
             $order_id = $params;
         }
 
+        $order = $this->order_model->getById($order_id);
+
         if (!$callback) {
             $plugin = $this->getPaymentPlugin($order_id);
             if ($plugin
@@ -59,7 +61,8 @@ class shopWorkflowCaptureAction extends shopWorkflowPayAction
             ) {
                 $transaction = $transactions[waPayment::TRANSACTION_CAPTURE];
                 try {
-                    $response = $plugin->capture(compact('transaction'));
+                    $order_data = $order;
+                    $response = $plugin->capture(compact('transaction', 'order_data'));
                 } catch (waException $ex) {
                     $message = sprintf(
                         "Error during capture order #%d: %s\nDATA:%s",
@@ -95,8 +98,6 @@ class shopWorkflowCaptureAction extends shopWorkflowPayAction
 
             }
         }
-
-        $order = $this->order_model->getById($order_id);
 
         if ($callback) {
             $this->waLog('order_capture_callback', $order_id, $order['contact_id']);


### PR DESCRIPTION
[Обещали](https://github.com/webasyst/webasyst-framework/blob/master/wa-system/payment/waPayment.class.php#L1425) же передать, а не передали :(

В случае такого варианта событий:
 1) заказ на 2000 руб. создан, переведён в холд;
 2) отредактирован менеджером (стало 1000 руб.);
 3) подтверждён менеджером.

Подтверждается только сумма **изначального заказа** (2000 руб.).
При этом в API платёжных систем иногда можно поменять сумму оплаты (иногда только в меньшую сторону).

Если параметр `$transaction_raw_data['order_data']` передан, то на стороне плагина уже можно разрешить данную ситуацию. Например, выдать ошибку ([пока только 500-ю 0_о](https://support.webasyst.ru/forum/34621/oshibka-500-pri-podtverzhdenii-platezha-v-dvukhstadiynoy-oplate/)) или передать по API другую сумму.

