### PR TITLE
Not all plugins has a 'description' field

### DIFF
--- a/lib/actions/settings/shipping/shopSettingsShipping.action.php
+++ b/lib/actions/settings/shipping/shopSettingsShipping.action.php
@@ -180,7 +180,7 @@ class shopSettingsShippingAction extends waViewAction
             if (!empty($plugin_info['handlers']['shipping_package'])) {
                 $shipping_package_provider['options'][$plugin_id] = array(
                     'name'  => $plugin_info['name'],
-                    'title' => $plugin_info['description'],
+                    'title' => ifset($plugin_info, 'description', ''),
                     'value' => $plugin_id,
                 );
             }


### PR DESCRIPTION
If 'description` isn't present in `plugin.php` PHP warns about invalid array key