### PR TITLE
Исправлен частный случай добавления копейки в скидку.

### DIFF
--- a/lib/classes/shopDiscounts.class.php
+++ b/lib/classes/shopDiscounts.class.php
@@ -773,9 +773,11 @@ HTML;
                         $total_items_discount_cents += $item_discount_cents;
                         $order['items'][$item_id]['total_discount'] += $item_discount_cents / $currency_precision;
                         $order['items'][$item_id]['smashed_discount_cents'] += $item_discount_cents;
-                    }
-                    if(!$order_discount_cents) {
-                        break;
+                        
+                        
+                        if(!$order_discount_cents) {
+                            break;
+                        }
                     }
                 } while ($min_item_discount_cents < abs($order_discount_cents));
             }


### PR DESCRIPTION
Проблема описана тут
https://support.webasyst.ru/forum/35516/posle-obnovleniya-freymvork-i-shop-script-ne-ubrat-01-kopeyku/

Решение в виде "делать скидку кратной кол-ву товаров" не подходит, т.к. оно, как минимум, нерабочее.

Сейчас нужно, чтобы остаток $order_discount_cents был кратным кол-ву товаров. Но, если он "был бы" кратный, то распределился бы до 0 на предыдущем шаге, и по идее до этой проверки вообще дело не дошло.....

А дальше, поскольку цикл foreach не прерывается на середине (в момент, когда уже все копейки распределили), скидка начинает добавляться/отниматься к следующему товару. Ну, и, в конце концов, **всегда будет изменена**.


**Воспроизведение.**
В заказе 3 товара, стоимостью
90360
61290
12200

Скидка 7800, 7801, ..., 7810
$order_discount_cents  остаётся всегда 1 или 2.


**Решение**
Остановить перебор внутреннего цикла, если уже ноль. Внешний остановится автоматически.