### PR TITLE
Fix. Не создаются "на лету" эскизы фото из отзывов.

### DIFF
--- a/lib/config/data/thumb.php
+++ b/lib/config/data/thumb.php
@@ -38,7 +38,7 @@ $size = false;
 $enable_2x = false;
 
 // /wa-data/public/shop/products/69/42/14269/images/194/194.96x96.jpg
-$image_pattern = '#^((?:\d{2}/){2}([0-9]+)/(?:reviews/[0-9]+/)images/)([0-9]+)/([a-zA-Z0-9_\.-]+)\.(\d+(?:x\d+)?)(@2x)?\.([a-z]{3,4})$#i';
+$image_pattern = '#^((?:\d{2}/){2}([0-9]+)/(?:reviews/[0-9]+/)?images/)([0-9]+)/([a-zA-Z0-9_\.-]+)\.(\d+(?:x\d+)?)(@2x)?\.([a-z]{3,4})$#i';
 // /wa-data/public/shop/products/69/42/14269/video/96x96.jpg
 $video_pattern = '#^((?:\d{2}/){2}([0-9]+)/video)/(\d+(?:x\d+)?)(@2x)?\.([a-z]{3,4})$#i';
 if (preg_match($image_pattern, $request_file, $matches)) {


### PR DESCRIPTION
Файл tumbs.php "не видит" фотографии отзывов к товару.
Из-за этого возникает проблема в двух случаях:

1) генерация эскизов заново
2) генерация превью отзыва произвольного размера.

Исправил регулярное выражение.