### PR TITLE
Bug fix: incorrect combine shipping dimensions features.

### DIFF
--- a/lib/classes/shopShipping.class.php
+++ b/lib/classes/shopShipping.class.php
@@ -268,7 +268,7 @@ class shopShipping extends waAppShipping
 
                 if (count($features) == 3) {
 	                foreach($dimension_fields as $dimension_field_key => $dimension_field) {
-		                $map[$dimension_field] = $features[$dimension_field] = $features[$dimensions[$dimension_field_key]];
+		                $map[$dimension_field] = $features[$dimensions[$dimension_field_key]];
 	                }
                     if (isset($units['dimensions'])) {
                         foreach ($dimension_fields as $field) {


### PR DESCRIPTION
В $features попадают характеристики в том порядке, в котором были созданы, по полю id. Когда они комбинируются с массивом $dimension_fields = [ 'height', 'width', 'length' ], они заполнятся некорректно, корректный порядок есть в $dimensions - там лежат значения id в нужном порядке [ HEIGHT_FEATURE_ID, WIDTH_FEATURE_ID, LENGTH_FEATURE_ID ].

Соответственно, нужно добавлять в $map характеристики размеров товаров именно так, как они указаны в настройках.