### PR TITLE
Add hook cart_items_after

### DIFF
--- a/lib/model/shopCartItems.model.php
+++ b/lib/model/shopCartItems.model.php
@@ -438,6 +438,10 @@ SQL;
             }
             $items = $result;
         }
+        
+        wa('shop')->event('cart_items_after', ref([
+            'items' => &$items
+        ]));
 
         return $items;
     }


### PR DESCRIPTION
Hook will help to change order items. 

I have plugin (Gift certificates), which changes prices of order items. One product can have different prices, depends on the amount of the certificate.
For now it's imposible to edit definite item in the order. I was trying to change item price with the help of `frontend_products` hook, but I found, that skus in some cases don't contain item ids. 

**What am I trying to achieve?** 
I want to:
- edit item price depends on certain item ID,
- calculate relevant order discount 
Method `shopCart::discount` use function `shopCartItemsModel::getByCode` to get order items. If you add hook `cart_items_after`, I will be able to change prices of the items.

**What issues have users?**
In some places of the website users see wrong discounts and item prices.