### PR TITLE
Добавить хук frontend_cart_add_items_after

### DIFF
--- a/lib/actions/frontend/shopFrontendCartAdd.controller.php
+++ b/lib/actions/frontend/shopFrontendCartAdd.controller.php
@@ -225,6 +225,11 @@ class shopFrontendCartAddController extends waJsonController
             $item['full_price'] = $this->currencyFormat($price, true);
             $items[] = $item;
         }
+        
+        wa('shop')->event('frontend_cart_add_items_after', ref([
+            'items' => &$items
+        ]));
+        
         return $items;
     }
 


### PR DESCRIPTION
При добавлении товара в корзину темы дизайна могут отправлять запрос вида:

`mydomain.com/cart/add/?items=1&html=1`

В результате в тему дизайна вернется набор товаров `items`, который хотелось бы менять: изменять картинку, название и тд.