### PR TITLE
Fix: wrong parameters passed to the `controller_after` event

### DIFF
--- a/lib/classes/shopFrontController.class.php
+++ b/lib/classes/shopFrontController.class.php
@@ -20,7 +20,7 @@ class shopFrontController extends waFrontController
             return;
         }
         $result = parent::runController($controller, $params);
-        wa('shop')->event('controller_after.'.$class, $params);
+        wa('shop')->event('controller_after.'.$class, $evt_params);
         return $result;
     }
 }


### PR DESCRIPTION
Сейчас в событие `controller_after` передаются параметры для контроллера, а не для события. И в обработчике нет возможности получить экземпляр контроллера. Ну и, кроме всего прочего, нынешняя ситуация не соответствует документации 😃